### PR TITLE
add interfaces and changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Circuit Breaker
+
+## Installation
+
+```bash
+composer require haaragard/circuit-breaker
+```
+
+## Supported laravel versions
+
+- 10.x
+- 11.x
+- 12.x
+
+## Overview
+

--- a/src/Adapter/LocalStorageAdapter.php
+++ b/src/Adapter/LocalStorageAdapter.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Haaragard\CircuitBreaker\Adapter;
 
-use Haaragard\CircuitBreaker\Config\Config;
 use Haaragard\CircuitBreaker\Contract\CircuitBreakerInterface;
+use Haaragard\CircuitBreaker\Contract\ConfigInterface;
 use Illuminate\Support\Carbon;
 
 class LocalStorageAdapter implements CircuitBreakerInterface
 {
     private array $container = [];
 
-    public function __construct(private Config $config)
+    public function __construct(private ConfigInterface $config)
     {
     }
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -4,20 +4,21 @@ declare(strict_types=1);
 
 namespace Haaragard\CircuitBreaker\Config;
 
+use Haaragard\CircuitBreaker\Contract\ConfigInterface;
 use InvalidArgumentException;
 
-class Config
+class Config implements ConfigInterface
 {
     public function __construct(
-        private bool $enabled,
-        private int $timeout,
-        private int $failureThreshold,
-        private int $resetTimeout,
+        protected bool $enabled,
+        protected int $timeout,
+        protected int $failureThreshold,
+        protected int $resetTimeout,
     ) {
         $this->validate();
     }
 
-    private function validate(): void
+    protected function validate(): void
     {
         if ($this->timeout <= 0) {
             throw new InvalidArgumentException('Timeout must be a positive integer.');

--- a/src/Contract/ConfigInterface.php
+++ b/src/Contract/ConfigInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haaragard\CircuitBreaker\Contract;
+
+interface ConfigInterface
+{
+    public function isEnabled(): bool;
+    public function getTimeout(): int;
+    public function getFailureThreshold(): int;
+    public function getResetTimeout(): int;
+}

--- a/src/Factory/CircuitBreakerFactory.php
+++ b/src/Factory/CircuitBreakerFactory.php
@@ -28,7 +28,7 @@ class CircuitBreakerFactory
             throw new InvalidArgumentException("Service configuration for '{$service}' not found.");
         }
 
-        $serviceClass = $serviceConfig['service'] ?? $this->getDefaultLocalStorageAdapter();
+        $serviceClass = $serviceConfig['service'] ?? $this->resolveDefaultLocalStorageAdapter();
         if (! class_exists($serviceClass)) {
             throw new InvalidArgumentException("Service class '{$serviceClass}' does not exist.");
         }
@@ -46,7 +46,7 @@ class CircuitBreakerFactory
         ]);
     }
 
-    private function getDefaultLocalStorageAdapter(): string
+    private function resolveDefaultLocalStorageAdapter(): string
     {
         return LocalStorageAdapter::class;
     }

--- a/src/Factory/CircuitBreakerFactory.php
+++ b/src/Factory/CircuitBreakerFactory.php
@@ -7,6 +7,7 @@ namespace Haaragard\CircuitBreaker\Factory;
 use Haaragard\CircuitBreaker\Adapter\LocalStorageAdapter;
 use Haaragard\CircuitBreaker\Config\Config;
 use Haaragard\CircuitBreaker\Contract\CircuitBreakerInterface;
+use Haaragard\CircuitBreaker\Contract\ConfigInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Foundation\Application;
 use InvalidArgumentException;
@@ -36,12 +37,13 @@ class CircuitBreakerFactory
             throw new InvalidArgumentException("Service class '{$serviceClass}' must implement " . CircuitBreakerInterface::class);
         }
 
+        $isCircuitBreakerEnabled = config('circuit-breaker.enabled', false);
+
         return $this->app->make($serviceClass, [
-            'config' => new Config(
-                enabled: config("circuit-breaker.enabled", false),
-                timeout: $serviceConfig['timeout'],
-                failureThreshold: $serviceConfig['failure_threshold'],
-                resetTimeout: $serviceConfig['reset_timeout'],
+            'config' => $this->resolveConfig(
+                $serviceClass,
+                $isCircuitBreakerEnabled,
+                $serviceConfig
             ),
         ]);
     }
@@ -49,5 +51,18 @@ class CircuitBreakerFactory
     private function resolveDefaultLocalStorageAdapter(): string
     {
         return LocalStorageAdapter::class;
+    }
+
+    private function resolveConfig(string $serviceClass, bool $isEnabled, array $config): ConfigInterface
+    {
+        return match ($serviceClass) {
+            LocalStorageAdapter::class => new Config(
+                enabled: $isEnabled,
+                timeout: $config['timeout'],
+                failureThreshold: $config['failure_threshold'],
+                resetTimeout: $config['reset_timeout'],
+            ),
+            default => throw new InvalidArgumentException("Unsupported service class '{$serviceClass}'."),
+        };
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to enhance the configurability, modularity, and documentation of the `Circuit Breaker` package. The most notable updates include the addition of an installation guide and Laravel version support to the documentation, the introduction of a `ConfigInterface` for better abstraction, modifications to the `Config` class to implement this interface, and updates to the factory logic to improve configuration handling.

### Documentation Updates:
* Added an "Installation" section with a `composer require` command to the `README.md`.
* Specified supported Laravel versions (10.x, 11.x, 12.x) in the `README.md`.

### Code Refactoring and Abstraction:
* Introduced a new `ConfigInterface` in `src/Contract/ConfigInterface.php` to define the configuration contract with methods like `isEnabled`, `getTimeout`, `getFailureThreshold`, and `getResetTimeout`.
* Updated the `Config` class in `src/Config/Config.php` to implement `ConfigInterface`, changed its properties from `private` to `protected`, and made the `validate` method `protected` for better extensibility.
* Modified the `LocalStorageAdapter` constructor in `src/Adapter/LocalStorageAdapter.php` to depend on `ConfigInterface` instead of the concrete `Config` class, improving flexibility.

### Factory Enhancements:
* Refactored `CircuitBreakerFactory` to introduce a `resolveConfig` method for creating `Config` instances dynamically based on the service class. This improves modularity and reduces hardcoding.
* Renamed `getDefaultLocalStorageAdapter` to `resolveDefaultLocalStorageAdapter` for better clarity in `CircuitBreakerFactory`.