### PR TITLE
Tests: add feature test for service provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
                 "Haaragard\\CircuitBreaker\\Provider\\ServiceProvider"
             ],
             "dont-discover": [
-                "Haaragard\\Test\\",
+                "Haaragard\\Test\\*",
                 "phpunit/phpunit",
                 "orchestra/testbench"
             ]

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,2 @@
+providers:
+  - Haaragard\CircuitBreaker\Provider\ServiceProvider

--- a/tests/Feature/FeatureTestCase.php
+++ b/tests/Feature/FeatureTestCase.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Haaragard\Test\Feature;
 
+use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\TestCase;
 
 class FeatureTestCase extends TestCase
 {
+    use WithWorkbench;
 }

--- a/tests/Feature/Provider/ServiceProviderTest.php
+++ b/tests/Feature/Provider/ServiceProviderTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haaragard\Test\Feature\Provider;
+
+use Haaragard\CircuitBreaker\Adapter\LocalStorageAdapter;
+use Haaragard\CircuitBreaker\Contract\CircuitBreakerInterface;
+use Haaragard\Test\Feature\FeatureTestCase;
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use PHPUnit\Framework\Attributes\Test;
+
+class ServiceProviderTest extends FeatureTestCase
+{
+    #[Test]
+    public function shouldMergeConfig(): void
+    {
+        $config = require __DIR__.'/../../../src/Config/circuit-breaker.php';
+        $providedConfig = config('circuit-breaker');
+
+        $this->assertEquals($config, $providedConfig);
+    }
+
+    #[Test]
+    public function shouldAppProvideInstanceCorrectly(): void
+    {
+        $expectedClass = LocalStorageAdapter::class;
+        $classInstance = $this->app->get(CircuitBreakerInterface::class);
+
+        $this->assertInstanceOf($expectedClass, $classInstance);
+    }
+}

--- a/tests/Feature/Provider/ServiceProviderTest.php
+++ b/tests/Feature/Provider/ServiceProviderTest.php
@@ -7,7 +7,6 @@ namespace Haaragard\Test\Feature\Provider;
 use Haaragard\CircuitBreaker\Adapter\LocalStorageAdapter;
 use Haaragard\CircuitBreaker\Contract\CircuitBreakerInterface;
 use Haaragard\Test\Feature\FeatureTestCase;
-use Orchestra\Testbench\Concerns\WithWorkbench;
 use PHPUnit\Framework\Attributes\Test;
 
 class ServiceProviderTest extends FeatureTestCase


### PR DESCRIPTION
This pull request introduces updates to improve the integration and testing of the `ServiceProvider` for the `CircuitBreaker` package. The changes include refining package discovery, adding a test configuration, enhancing the base test case with additional functionality, and introducing new feature tests for the `ServiceProvider`.

### Integration Updates:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L32-R32): Adjusted the `dont-discover` configuration to use a wildcard pattern for excluding `Haaragard\Test\` during package discovery.

* [`testbench.yaml`](diffhunk://#diff-ef7834cd1991a169c5e09ee7b61b72255e1feabf34bb85a21c75fc6fa532917aR1-R2): Added the `Haaragard\CircuitBreaker\Provider\ServiceProvider` to the list of providers for testing purposes.

### Testing Enhancements:
* [`tests/Feature/FeatureTestCase.php`](diffhunk://#diff-23a08f3ba53640719a848da02cb35c488b634382011fe82ec6df184d2c9c4218R7-R12): Added the `WithWorkbench` trait to the base feature test case to enable additional testing capabilities provided by `Orchestra\Testbench`.

* [`tests/Feature/Provider/ServiceProviderTest.php`](diffhunk://#diff-ec65a99a9ea65aebee3381ab970fde11fb8c573f7983b24a660e1384622d14f2R1-R31): Introduced a new test class to verify the `ServiceProvider` functionality. It includes tests to ensure configuration merging and correct instance provision for the `CircuitBreakerInterface`.