### PR TITLE
Feature: refactor things

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,26 +23,66 @@ php artisan vendor:publish --tag=haaragard-circuit-breaker-config
 
 ## How it works
 
+### Plug-and-play
+
+Using right after the installation is possible, as the package comes with a default configuration that uses the `LocalStorageAdapter` driver.
+This driver stores the circuit breaker state in-memory and is suitable for local development or testing purposes.
+
 ```php
 // Initialize the circuit breaker from the service container
 $circuitBreaker = app()->get(CircuitBreakerInterface::class);
 
 // Check if the circuit breaker is open
-$isOpen = $circuitBreaker->isOpen(self::class);
+$isOpen = $circuitBreaker->isOpen('string-key');
 
 // Record a failure
-$circuitBreaker->recordFailure(self::class);
+$circuitBreaker->recordFailure('string-key');
 
 // Record a success
-$circuitBreaker->recordSuccess(self::class);
+$circuitBreaker->recordSuccess('string-key');
 
 // Reset
-$circuitBreaker->reset(self::class);
+$circuitBreaker->reset('string-key');
 
 // ForceReset
-$circuitBreaker->forceReset(self::class);
+$circuitBreaker->forceReset('string-key');
 ```
 
-You can also give any `string` as the first parameter to the methods above, 
-which will be used as the circuit breaker name. 
+You can also give any `string` as the first parameter to the methods above,
+which will be used as the circuit breaker name.
 This allows you to have multiple circuit breakers for different purposes.
+
+### Changing the default config
+
+You can change the default configuration by publishing the config file and modifying it to your needs.
+
+```bash
+php artisan vendor:publish --tag=haaragard-circuit-breaker-config
+```
+
+### Laravel Custom Cache Drivers
+
+You can use any cache driver supported by Laravel by changing the `driver` key in the configuration file.
+The CacheStorageAdapter supports all laravel cache drivers, including your custom ones as long as they implement
+and works as expected with the Laravel Cache facade.
+
+```php
+<?php
+
+// circuit-breaker.php
+
+return [
+    'enabled' => true,
+    'service' => 'cache',
+    'services' => [
+        'cache' => [
+            'timeout' => 10_000,
+            'failure_threshold' => 5,
+            'reset_timeout' => 30_000,
+            'key_prefix' => 'circuit-breaker:',
+            'cache_connection' => 'default', // Any cache connection supported by Laravel, plus the custom ones.
+            'service' => \Haaragard\CircuitBreaker\Adapter\CacheStorageAdapter::class,
+        ],
+    ],
+];
+```

--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ and works as expected with the Laravel Cache facade.
 
 ```php
 <?php
-
 // circuit-breaker.php
 
 return [
@@ -232,7 +231,6 @@ If you need a custom circuit breaker driver, you can create one by implementing 
 
 ```php
 <?php
-
 // circuit-breaker.php
 
 return [

--- a/README.md
+++ b/README.md
@@ -225,3 +225,27 @@ return [
     ],
 ];
 ```
+
+### Custom Circuit Breaker Drivers
+
+If you need a custom circuit breaker driver, you can create one by implementing the `CircuitBreakerInterface` interface.
+
+```php
+<?php
+
+// circuit-breaker.php
+
+return [
+    'enabled' => true,
+    'service' => 'my_own_driver',
+    'services' => [
+        'my_own_driver' => [
+            // You can define any configuration you need for your custom driver here.
+            // ...
+
+            'service' => \PathToMyOwnDriver\MyOwnDriver::class, // Mandatory. Needs to implement the `CircuitBreakerInterface`
+            'config' => \PathToMyOwnDriverConfig\MyOwnDriverConfig::class, // Mandatory.
+        ],
+    ],
+];
+```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,145 @@ You can change the default configuration by publishing the config file and modif
 php artisan vendor:publish --tag=haaragard-circuit-breaker-config
 ```
 
+### Configs
+
+Key: `enabled` - (`bool`) If set to `true`, the circuit breaker will be enabled. If set to `false`, it will be disabled.
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'enabled' => true,
+];
+```
+
+Key: `service` - (`string`) The service to use for the circuit breaker. This can be any **key** service that is listed on `services` **array**.
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'service' => 'default',
+];
+```
+
+Key: `services` - (`array`) The services that can be used for the circuit breaker. Each service must have a `service` key that points to the class that implements the `CircuitBreakerInterface`.
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'services' => [
+        'default' => [
+            'timeout' => 10_000,
+            'failure_threshold' => 5,
+            'reset_timeout' => 30_000,
+            'key_prefix' => 'circuit-breaker:',
+            'cache_connection' => 'default', // Any cache connection supported by Laravel, plus the custom ones.
+            'service' => \Haaragard\CircuitBreaker\Adapter\CacheStorageAdapter::class,
+        ],
+    ],
+];
+```
+
+Key: `timeout` - (`int`) The timeout in milliseconds for the circuit breaker fail counter. This is the time after which the circuit breaker will be reset the failures before reaching the `failure_threshold`.
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'services' => [
+        'default' => [
+            'timeout' => 10_000,
+        ],
+    ],
+];
+```
+
+Key: `failure_threshold` - (`int`) The number of failures before the circuit breaker is opened. After this threshold is reached, the circuit breaker will be closed and will not allow any requests to pass through until it is reset by the `reset_timeout`.
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'services' => [
+        'default' => [
+            'failure_threshold' => 5,
+        ],
+    ],
+];
+```
+
+Key: `reset_timeout` - (`int`) The time in milliseconds after which the circuit breaker will be reset and will allow requests to pass through again. This is the time after which the circuit breaker will be reset and will allow requests to pass through again.
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'services' => [
+        'default' => [
+            'reset_timeout' => 30_000,
+        ],
+    ],
+];
+```
+
+Key: `key_prefix` - (`string`) The prefix to use for the circuit breaker keys in the storage. This is useful to avoid key collisions in the storage. _(Only in Cache)_
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'services' => [
+        'default' => [
+            'key_prefix' => 'circuit-breaker:',
+        ],
+    ],
+];
+```
+
+Key: `cache_connection` - (`string`) The cache connection to use for the circuit breaker. This can be any cache connection supported by Laravel, plus the custom ones.  _(Only in Cache)_
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'services' => [
+        'default' => [
+            'cache_connection' => 'default', // Any cache connection supported by Laravel, plus the custom ones.
+        ],
+    ],
+];
+```
+
+Key: `service` - (`string`) The service to use for the circuit breaker. This must be a class that implements the `\Haaragard\CircuitBreaker\Contract\CircuitBreakerInterface::class`. _(For custom Drivers only)_
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'services' => [
+        'default' => [
+            'service' => \Haaragard\CircuitBreaker\Contract\CircuitBreakerInterface::class,
+        ],
+    ],
+];
+```
+
+Key: `config` - (`string`) The configuration class to use for the circuit breaker. This is mandatory for custom drivers and must implement the `\Haaragard\CircuitBreaker\Contract\ConfigInterface::class`. _(For custom Drivers only)_
+```php
+<?php
+// circuit-breaker.php
+
+return [
+    'services' => [
+        'default' => [
+            'config' => \Haaragard\CircuitBreaker\Contract\ConfigInterface::class,
+        ],
+    ],
+];
+```
+
 ### Laravel Custom Cache Drivers
 
 You can use any cache driver supported by Laravel by changing the `driver` key in the configuration file.

--- a/src/Adapter/CacheStorageAdapter.php
+++ b/src/Adapter/CacheStorageAdapter.php
@@ -119,10 +119,8 @@ class CacheStorageAdapter implements CircuitBreakerInterface
     {
         $lastFailureKey = $this->resolveKey($key) . self::CACHE_KEY_SUFFIX_LAST_FAILURE;
         $lastFailureTimestamp = $this->cacheRepository->get($lastFailureKey, 0);
+
         $lastFailure = Carbon::createFromTimestamp($lastFailureTimestamp);
-        if (is_null($lastFailure)) {
-            return false;
-        }
         $lastFailure->addMilliseconds($this->config->getTimeout());
 
         return Carbon::now()->gt($lastFailure->toDateTimeImmutable());

--- a/src/Config/circuit-breaker.php
+++ b/src/Config/circuit-breaker.php
@@ -2,35 +2,25 @@
 
 declare(strict_types=1);
 
-use Haaragard\CircuitBreaker\Adapter\CacheStorageAdapter;
-
 return [
     'enabled' => true,
 
-    'service' => 'default', // Default service name for circuit breaker
+    'service' => 'default',
 
-    // Services registration for circuit breaker
     'services' => [
         'default' => [
-            'timeout' => 10_000, // Timeout in milliseconds
-            'failure_threshold' => 5, // Number of failures before circuit opens
-            'reset_timeout' => 30_000, // Time in milliseconds before circuit resets
-        ], // Default service implementation for circuit breaker
-
+            'timeout' => 10_000,
+            'failure_threshold' => 5,
+            'reset_timeout' => 30_000,
+            'service' => \Haaragard\CircuitBreaker\Adapter\LocalStorageAdapter::class,
+        ],
         'cache' => [
-            'timeout' => 10_000, // Timeout in milliseconds
-            'failure_threshold' => 5, // Number of failures before circuit opens
-            'reset_timeout' => 30_000, // Time in milliseconds before circuit resets
-            'key_prefix' => 'circuit-breaker:', // Prefix for cache keys
-            'cache_connection' => 'default', // Cache connection name
-            'service' => CacheStorageAdapter::class, // Default service name
-        ], // Default service implementation for circuit breaker
-
-//        'new-service' => [
-//            'timeout' => 1_000, // Timeout in milliseconds
-//            'failure_threshold' => 5, // Number of failures before circuit opens
-//            'reset_timeout' => 5_000, // Time in milliseconds before circuit resets
-//            'service' => '\Haaragard\CircuitBreaker\Contract\CircuitBreakerInterface-class-implementation-with', // Default service name
-//        ], // Default service implementation for circuit breaker
+            'timeout' => 10_000,
+            'failure_threshold' => 5,
+            'reset_timeout' => 30_000,
+            'key_prefix' => 'circuit-breaker:',
+            'cache_connection' => 'default',
+            'service' => \Haaragard\CircuitBreaker\Adapter\CacheStorageAdapter::class,
+        ],
     ],
 ];

--- a/src/Factory/CircuitBreakerFactory.php
+++ b/src/Factory/CircuitBreakerFactory.php
@@ -4,13 +4,7 @@ declare(strict_types=1);
 
 namespace Haaragard\CircuitBreaker\Factory;
 
-use Haaragard\CircuitBreaker\Adapter\CacheStorageAdapter;
-use Haaragard\CircuitBreaker\Adapter\LocalStorageAdapter;
-use Haaragard\CircuitBreaker\Config\CacheConfig;
-use Haaragard\CircuitBreaker\Config\Config;
-use Haaragard\CircuitBreaker\Contract\CacheConfigInterface;
 use Haaragard\CircuitBreaker\Contract\CircuitBreakerInterface;
-use Haaragard\CircuitBreaker\Contract\ConfigInterface;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Foundation\Application;
 use InvalidArgumentException;
@@ -32,8 +26,8 @@ class CircuitBreakerFactory
             throw new InvalidArgumentException("Service configuration for '{$service}' not found.");
         }
 
-        $serviceClass = $serviceConfig['service'] ?? $this->resolveDefaultLocalStorageAdapter();
-        if (! class_exists($serviceClass)) {
+        $serviceClass = $serviceConfig['service'];
+        if (is_null($serviceClass) || ! class_exists($serviceClass)) {
             throw new InvalidArgumentException("Service class '{$serviceClass}' does not exist.");
         }
         if (! in_array(CircuitBreakerInterface::class, class_implements($serviceClass), true)) {
@@ -43,37 +37,11 @@ class CircuitBreakerFactory
         $isCircuitBreakerEnabled = config('circuit-breaker.enabled', false);
 
         return $this->app->make($serviceClass, [
-            'config' => $this->resolveConfig(
+            'config' => (new ConfigFactory)(
                 $serviceClass,
                 $isCircuitBreakerEnabled,
                 $serviceConfig
             ),
         ]);
-    }
-
-    private function resolveDefaultLocalStorageAdapter(): string
-    {
-        return LocalStorageAdapter::class;
-    }
-
-    private function resolveConfig(string $serviceClass, bool $isEnabled, array $config): ConfigInterface|CacheConfigInterface
-    {
-        return match ($serviceClass) {
-            LocalStorageAdapter::class => new Config(
-                enabled: $isEnabled,
-                timeout: $config['timeout'],
-                failureThreshold: $config['failure_threshold'],
-                resetTimeout: $config['reset_timeout'],
-            ),
-            CacheStorageAdapter::class => new CacheConfig(
-                enabled: $isEnabled,
-                timeout: $config['timeout'],
-                failureThreshold: $config['failure_threshold'],
-                resetTimeout: $config['reset_timeout'],
-                keyPrefix: $config['key_prefix'],
-                cacheConnection: $config['cache_connection'],
-            ),
-            default => throw new InvalidArgumentException("Unsupported service class '{$serviceClass}'."),
-        };
     }
 }

--- a/src/Factory/ConfigFactory.php
+++ b/src/Factory/ConfigFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Haaragard\CircuitBreaker\Factory;
+
+use Haaragard\CircuitBreaker\Adapter\CacheStorageAdapter;
+use Haaragard\CircuitBreaker\Adapter\LocalStorageAdapter;
+use Haaragard\CircuitBreaker\Config\CacheConfig;
+use Haaragard\CircuitBreaker\Config\Config;
+use Haaragard\CircuitBreaker\Contract\ConfigInterface;
+use InvalidArgumentException;
+
+class ConfigFactory
+{
+    public function __invoke(
+        string $serviceClass,
+        bool $isEnabled,
+        array $config
+    ): ConfigInterface {
+        return match ($serviceClass) {
+            LocalStorageAdapter::class => new Config(
+                enabled: $isEnabled,
+                timeout: $config['timeout'],
+                failureThreshold: $config['failure_threshold'],
+                resetTimeout: $config['reset_timeout'],
+            ),
+            CacheStorageAdapter::class => new CacheConfig(
+                enabled: $isEnabled,
+                timeout: $config['timeout'],
+                failureThreshold: $config['failure_threshold'],
+                resetTimeout: $config['reset_timeout'],
+                keyPrefix: $config['key_prefix'],
+                cacheConnection: $config['cache_connection'],
+            ),
+            default => $this->resolveCustomConfig($isEnabled, $config),
+        };
+    }
+
+    private function resolveCustomConfig(bool $isEnabled, array $config): ConfigInterface
+    {
+        $configClass = $config['config'] ?? null;
+        if (is_null($configClass) || ! class_exists($configClass)) {
+            throw new InvalidArgumentException(
+                "Configuration class '{$configClass}' does not exist."
+            );
+        }
+
+        unset($config['config'], $config['service']);
+
+        $configWithKeysCammel = $this->convertKeysToCamelCase($config);
+        $configWithKeysCammel['enabled'] = $isEnabled;
+
+        return new $configClass(...$configWithKeysCammel);
+    }
+
+    private function convertKeysToCamelCase(array $array): array
+    {
+        if (empty($array)) {
+            return [];
+        }
+
+        return array_combine(
+            array_map(
+                static fn ($key) => lcfirst(
+                    str_replace('_', '', ucwords($key, '_'))
+                ),
+                array_keys($array)
+            ),
+            array_values($array)
+        );
+    }
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the circuit breaker package, including improved configurability, refactoring for better maintainability, and support for custom drivers. Key changes include the addition of a `ConfigFactory` class for dynamic configuration handling, updates to the default configuration, and the removal of redundant logic in the factory class.

### Enhancements to Configurability:
* Added detailed documentation in `README.md` on how to customize the circuit breaker configuration, including new configuration keys like `timeout`, `failure_threshold`, and `reset_timeout`. It also explains how to use Laravel custom cache drivers and create custom circuit breaker drivers.
* Updated the default configuration file `src/Config/circuit-breaker.php` to include a `LocalStorageAdapter` as the default service and removed redundant comments for clarity.

### Code Refactoring:
* Introduced a new `ConfigFactory` class (`src/Factory/ConfigFactory.php`) to handle the creation of configuration objects dynamically, supporting both built-in and custom drivers. This replaces the `resolveConfig` method and simplifies the `CircuitBreakerFactory` class.
* Removed the `resolveDefaultLocalStorageAdapter` and `resolveConfig` methods from `CircuitBreakerFactory` and replaced them with a call to `ConfigFactory`.

### Bug Fixes and Cleanup:
* Fixed a bug in `CacheStorageAdapter` where the `isLastFailureExpiredFromCounter` method unnecessarily checked for null values. This check was removed for correctness and simplicity.
* Removed unused imports from `CircuitBreakerFactory` to clean up the codebase.